### PR TITLE
CSV shorthand

### DIFF
--- a/difftest.ml
+++ b/difftest.ml
@@ -151,12 +151,12 @@ let difftest () =
 let difftest_json () =
   List.mapi
     (fun i (test, result) ->
-      let name, anonymous =
+      let name =
         match test with
         | Named name ->
-            (name, false)
+            name
         | Anonymous ->
-            (sprintf "anonymous-%s" (string_of_int i), true)
+            sprintf "anonymous-%s" (string_of_int i)
       and result, summary, misc =
         match result with
         | Ok summary ->
@@ -173,7 +173,6 @@ let difftest_json () =
             ("failed", summary, partial_success)
       in
       [ ("example", `String name)
-      ; ("anonymous", `Bool anonymous)
       ; ("result", `String result)
       ; ("summary", `String summary) ]
       @ misc)

--- a/dune
+++ b/dune
@@ -7,6 +7,7 @@
  (alias runtest)
  (deps
   difftest.exe
+  ../examples/examples.csv
   (glob_files ../examples/*.lisp)
   (glob_files ../examples/*.out)
   (glob_files ../examples/*.err))

--- a/dune
+++ b/dune
@@ -7,7 +7,7 @@
  (alias runtest)
  (deps
   difftest.exe
-  ../examples/examples.csv
+  (glob_files ../examples/examples.csv)
   (glob_files ../examples/*.lisp)
   (glob_files ../examples/*.out)
   (glob_files ../examples/*.err))


### PR DESCRIPTION
This makes it possible to write examples in an `examples/examples.csv` file of the following format:

```csv
<PROGRAM>, <EXPECTED (optional)>
(* 1 2), 2
(- 4 2)
```

Each cell has its contents trimmed of leading and trailing whitespace.